### PR TITLE
feat(graphql): add publicationState filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ await fetch(`${API_URL}/api/slugify/slugs/article/lorem-ipsum-dolor`);
 }
 ```
 
-Additionally a `publicationState` arg can be passed to the GraphQl query that accepts either `preview` or `live` as input, if `draftAndPublish`
-is enabled for the content-type.
+Additionally  if `draftAndPublish` is enabled for the content-type a `publicationState` arg can be passed to the GraphQL query that accepts either `preview` or `live` as input.
 
 **IMPORTANT** Please beware that the request for an entry in `preview` will return both draft entries & published entries as per Strapi default.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Any time the respective content types have an entity created or updated the slug
 
 ### Find One by Slug
 
-Hitting the `/api/slugify/slugs/:modelName/:slug` endpoint for any configured content types will return the entity type that matches the slug in the url.
+Hitting the `/api/slugify/slugs/:modelName/:slug` endpoint for any configured content types will return the entity type that matches the slug in the url. Additionally an optional query parameter of `/api/slugify/slugs/:modelName/:slug?publicationState=<publicationState>` can be appended to the request, which accepts either `live` or `preview` as a parameter and will return a content type according to its publication state.
 
 **IMPORTANT** The modelName is case sensitive and must match exactly with the name defined in the configuration.
 
@@ -99,7 +99,7 @@ Making the following request with the sample configuration will look as follows
 #### REST
 
 ```js
-await fetch(`${API_URL}/api/slugify/slugs/article/lorem-ipsum-dolor`);
+await fetch(`${API_URL}/api/slugify/slugs/article/lorem-ipsum-dolor?publicationState=preview`);
 // GET /api/slugify/slugs/article/lorem-ipsum-dolor
 ```
 
@@ -107,7 +107,7 @@ await fetch(`${API_URL}/api/slugify/slugs/article/lorem-ipsum-dolor`);
 
 ```graphql
 {
-  findSlug(modelName:"article",slug:"lorem-ipsum-dolor"){
+  findSlug(modelName:"article",slug:"lorem-ipsum-dolor",publicationState:"preview"){
     ... on ArticleEntityResponse{
       data{
         id

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Any time the respective content types have an entity created or updated the slug
 
 ### Find One by Slug
 
-Hitting the `/api/slugify/slugs/:modelName/:slug` endpoint for any configured content types will return the entity type that matches the slug in the url. Additionally an optional query parameter of `/api/slugify/slugs/:modelName/:slug?publicationState=<publicationState>` can be appended to the request, which accepts either `live` or `preview` as a parameter and will return a content type according to its publication state.
+Hitting the `/api/slugify/slugs/:modelName/:slug` endpoint for any configured content types will return the entity type that matches the slug in the url. Additionally the endpoint accepts any of the parameters that can be added to the routes built into Strapi.
 
 **IMPORTANT** The modelName is case sensitive and must match exactly with the name defined in the configuration.
 
@@ -99,11 +99,31 @@ Making the following request with the sample configuration will look as follows
 #### REST
 
 ```js
-await fetch(`${API_URL}/api/slugify/slugs/article/lorem-ipsum-dolor?publicationState=preview`);
+await fetch(`${API_URL}/api/slugify/slugs/article/lorem-ipsum-dolor`);
 // GET /api/slugify/slugs/article/lorem-ipsum-dolor
 ```
 
 #### GraphQL
+
+```graphql
+{
+  findSlug(modelName:"article",slug:"lorem-ipsum-dolor"){
+    ... on ArticleEntityResponse{
+      data{
+        id
+        attributes{
+          title
+        }
+      }
+    }
+  }
+}
+```
+
+Additionally a `publicationState` arg can be passed to the GraphQl query that accepts either `preview` or `live` as input, if `draftAndPublish`
+is enabled for the content-type.
+
+**IMPORTANT** Please beware that the request for an entry in `preview` will return both draft entries & published entries as per Strapi default.
 
 ```graphql
 {

--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -72,13 +72,9 @@ const getCustomTypes = (strapi, nexus) => {
 							},
 						};
 
-						// return entries based on publicationState arg or default to only returning published entries when draftAndPublish mode is enabled
+						// only return published entries by default if content type has draftAndPublish enabled
 						if (_.get(contentType, ['options', 'draftAndPublish'], false)) {
-							query.publicationState = "live";
-							
-							if (publicationState) {
-								query.publicationState = publicationState;
-							}
+							query.publicationState = publicationState || 'live';
 						} 
 
 						const data = await getPluginService(strapi, 'slugService').findOne(uid, query);

--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -51,13 +51,14 @@ const getCustomTypes = (strapi, nexus) => {
 					},
 					resolve: async (_parent, args, ctx) => {
 						const { models } = getPluginService(strapi, 'settingsService').get();
-						const { modelName, slug } = args;
+						const { modelName, slug, publicationState } = args;
 						const { auth } = ctx.state;
 
 						isValidFindSlugParams({
 							modelName,
 							slug,
 							models,
+							publicationState
 						});
 
 						const { uid, field, contentType } = models[modelName];
@@ -72,11 +73,13 @@ const getCustomTypes = (strapi, nexus) => {
 						};
 
 						// return entries based on publicationState arg or default to only returning published entries when draftAndPublish mode is enabled
-						if (_.get(contentType, ['options', 'draftAndPublish'], false) && publicationState) {
-							query.publicationState = publicationState;
-						} else if (_.get(contentType, ['options', 'draftAndPublish'], false)) {
+						if (_.get(contentType, ['options', 'draftAndPublish'], false)) {
 							query.publicationState = "live";
-						}
+							
+							if (publicationState) {
+								query.publicationState = publicationState;
+							}
+						} 
 
 						const data = await getPluginService(strapi, 'slugService').findOne(uid, query);
 						const sanitizedEntity = await sanitizeOutput(data, contentType, auth);

--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -45,10 +45,11 @@ const getCustomTypes = (strapi, nexus) => {
 					args: {
 						modelName: nexus.stringArg('The model name of the content type'),
 						slug: nexus.stringArg('The slug to query for'),
+						publicationState: nexus.stringArg('The publication state of the entry')
 					},
 					resolve: async (_parent, args) => {
 						const { models } = getPluginService(strapi, 'settingsService').get();
-						const { modelName, slug } = args;
+						const { modelName, slug, publicationState } = args;
 
 						const model = models[modelName];
 
@@ -66,12 +67,15 @@ const getCustomTypes = (strapi, nexus) => {
 							},
 						};
 
-						// only return published entries
-						if (_.get(contentType, ['options', 'draftAndPublish'], false)) {
-							query.publicationState = 'live';
+						// return entries based on publicationState arg or default to only returning published entries when draftAndPublish mode is enabled
+						if (_.get(contentType, ['options', 'draftAndPublish'], false) && publicationState) {
+							query.publicationState = publicationState;
+						} else if (_.get(contentType, ['options', 'draftAndPublish'], false)) {
+							query.publicationState = "live";
 						}
 
 						const data = await getPluginService(strapi, 'slugService').findOne(uid, query);
+
 						return toEntityResponse(data, { resourceUID: uid });
 					},
 				});

--- a/server/utils/isValidFindSlugParams.js
+++ b/server/utils/isValidFindSlugParams.js
@@ -17,7 +17,7 @@ const isValidFindSlugParams = (params) => {
 		throw new ValidationError('A slug path variable is required.');
 	}
 
-	if (_.get(contentType, ['options', 'draftAndPublish'], false) && publicationState) {
+	if (_.get(model, ['contentType', 'options', 'draftAndPublish'], false) && publicationState) {
 		throw new ValidationError('Filtering by publication state is only supported for content types that have Draft and Publish enabled.')
 	}
 

--- a/server/utils/isValidFindSlugParams.js
+++ b/server/utils/isValidFindSlugParams.js
@@ -17,7 +17,7 @@ const isValidFindSlugParams = (params) => {
 	}
 
 	if (!model.contentType.options.draftAndPublish && publicationState) {
-		throw new ValidationError('Draft and Publish is not enabled for this content-type. Please enable Draft and Publish if you want to filter by publication state.')
+		throw new ValidationError('Filtering by publication state is only supported for content types that have Draft and Publish enabled.')
 	}
 
 	// ensure valid model is passed

--- a/server/utils/isValidFindSlugParams.js
+++ b/server/utils/isValidFindSlugParams.js
@@ -5,7 +5,8 @@ const isValidFindSlugParams = (params) => {
 		throw new ValidationError('A model and slug must be provided.');
 	}
 
-	const { modelName, slug, models } = params;
+	const { modelName, slug, models, publicationState } = params;
+	const model = models[modelName];
 
 	if (!modelName) {
 		throw new ValidationError('A model name path variable is required.');
@@ -15,7 +16,9 @@ const isValidFindSlugParams = (params) => {
 		throw new ValidationError('A slug path variable is required.');
 	}
 
-	const model = models[modelName];
+	if (!model.contentType.options.draftAndPublish && publicationState) {
+		throw new ValidationError('Draft and Publish is not enabled for this content-type. Please enable Draft and Publish if you want to filter by publication state.')
+	}
 
 	// ensure valid model is passed
 	if (!model) {

--- a/server/utils/isValidFindSlugParams.js
+++ b/server/utils/isValidFindSlugParams.js
@@ -1,4 +1,5 @@
 const { ValidationError } = require('@strapi/utils/lib/errors');
+const _ = require('lodash');
 
 const isValidFindSlugParams = (params) => {
 	if (!params) {
@@ -16,7 +17,7 @@ const isValidFindSlugParams = (params) => {
 		throw new ValidationError('A slug path variable is required.');
 	}
 
-	if (!model.contentType.options.draftAndPublish && publicationState) {
+	if (_.get(contentType, ['options', 'draftAndPublish'], false) && publicationState) {
 		throw new ValidationError('Filtering by publication state is only supported for content types that have Draft and Publish enabled.')
 	}
 


### PR DESCRIPTION
Hey there,
thanks for this awesome plugin!

Working on a project right now, I felt the need to be able to query for unpublished content types - to generate Preview Links for a Next.js frontend more specifically.

I took the liberty to expand the logic in the graphql type, as well as the slugController.

With these changes publicationState can be added as an optional arg to the fingSlug query and can be passed to the regular REST endpoint as an optional query param.