### PR TITLE
Fix permission issue

### DIFF
--- a/server/controllers/slug-controller.js
+++ b/server/controllers/slug-controller.js
@@ -44,7 +44,8 @@ module.exports = ({ strapi }) => ({
 			const data = await getPluginService(strapi, 'slugService').findOne(uid, query);
 
 			if (data) {
-				const sanitizedEntity = await sanitize.contentAPI.output(data, contentType);
+				const auth = ctx.state.auth || {};
+				const sanitizedEntity = await sanitize.contentAPI.output(data, contentType, { auth });
 				ctx.body = transformResponse(sanitizedEntity);
 			} else {
 				ctx.notFound();


### PR DESCRIPTION
Currently the plugin bypasses the permission checks of the users-permissions plugin.

To reproduce the fix, disable a content type's permissions for the public role. It won't be available through Strapi's `/api/:contentType` route anymore. But you can still access it on the `/api/slugify/slugs/:modelName/:slug` route, which is a security issue.

To fix it, I added auth information when sanitizing the response. It's what we do on our [content API](https://github.com/strapi/strapi/blob/0f9b69298b2d94b31b434bd7217060570ae89374/packages/core/strapi/lib/core-api/controller/index.js#L24).