### PR TITLE
fix: broken check for draftAndPublished

### DIFF
--- a/server/utils/isValidFindSlugParams.js
+++ b/server/utils/isValidFindSlugParams.js
@@ -17,7 +17,7 @@ const isValidFindSlugParams = (params) => {
 		throw new ValidationError('A slug path variable is required.');
 	}
 
-	if (_.get(model, ['contentType', 'options', 'draftAndPublish'], false) && publicationState) {
+	if (!_.get(model, ['contentType', 'options', 'draftAndPublish'], false) && publicationState) {
 		throw new ValidationError('Filtering by publication state is only supported for content types that have Draft and Publish enabled.')
 	}
 


### PR DESCRIPTION
I don't know how I missed this. The Check was implemented in the wrong way and was throwing the ValidationError for contentTypes that have darftAndPublished enabled.