### PR TITLE
fix(registration): error on install with gql

### DIFF
--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -47,7 +47,7 @@ const getCustomTypes = (strapi, nexus) => {
 					args: {
 						modelName: nexus.stringArg('The model name of the content type'),
 						slug: nexus.stringArg('The slug to query for'),
-						publicationState: nexus.stringArg('The publication state of the entry')
+						publicationState: nexus.stringArg('The publication state of the entry'),
 					},
 					resolve: async (_parent, args, ctx) => {
 						const { models } = getPluginService(strapi, 'settingsService').get();
@@ -58,7 +58,7 @@ const getCustomTypes = (strapi, nexus) => {
 							modelName,
 							slug,
 							models,
-							publicationState
+							publicationState,
 						});
 
 						const { uid, field, contentType } = models[modelName];
@@ -75,7 +75,7 @@ const getCustomTypes = (strapi, nexus) => {
 						// only return published entries by default if content type has draftAndPublish enabled
 						if (_.get(contentType, ['options', 'draftAndPublish'], false)) {
 							query.publicationState = publicationState || 'live';
-						} 
+						}
 
 						const data = await getPluginService(strapi, 'slugService').findOne(uid, query);
 						const sanitizedEntity = await sanitizeOutput(data, contentType, auth);

--- a/server/register.js
+++ b/server/register.js
@@ -1,8 +1,15 @@
 'use strict';
 
 const { registerGraphlQLQuery } = require('./graphql');
+const { getPluginService } = require('./utils/getPluginService');
 
 module.exports = ({ strapi }) => {
+	const { contentTypes } = getPluginService(strapi, 'settingsService').get();
+
+	// ensure we have at least one model before attempting registration
+	if (!Object.keys(contentTypes).length) {
+		return;
+	}
 	// add graphql query if present
 	if (strapi.plugin('graphql')) {
 		strapi.log.info('[slugify] graphql detected, registering queries');

--- a/server/utils/isValidFindSlugParams.js
+++ b/server/utils/isValidFindSlugParams.js
@@ -18,7 +18,9 @@ const isValidFindSlugParams = (params) => {
 	}
 
 	if (!_.get(model, ['contentType', 'options', 'draftAndPublish'], false) && publicationState) {
-		throw new ValidationError('Filtering by publication state is only supported for content types that have Draft and Publish enabled.')
+		throw new ValidationError(
+			'Filtering by publication state is only supported for content types that have Draft and Publish enabled.'
+		);
 	}
 
 	// ensure valid model is passed


### PR DESCRIPTION
This PR introduces the follwing changes
- ensure the plugin no longer errors on default settings with gql enabled.

### Resolves Issue(s)
- #35 
- #51

