### PR TITLE
Bug: SlugifyWithCount will continue to increase the count when saving models via the Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Per [#35](https://github.com/ComfortablyCoding/strapi-plugin-slugify/issues/35) 
 | contentTypes[modelName]field | The name of the field to add the slug  | String | N/A | Yes |
 | contentTypes[modelName]references | The name(s) of the field(s) used to build the slug. If an array of fields is set it will result in a compound slug | String or Array | N/A | Yes |
 | slugifyWithCount | Duplicate strings will have their occurrence appended to the end of the slug | Boolean | false | No |
+| updateSlugs | If referenced fields have updates also update the slug. | Boolean | false | No |
 | skipUndefinedReferences | Skip reference fields that have no data. Mostly applicable to compound slug | Boolean | false | No |
 | slugifyOptions | The options to pass the the slugify function. All options can be found in the [slugify docs](https://github.com/sindresorhus/slugify#api) | Object | {} | No |
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Per [#35](https://github.com/ComfortablyCoding/strapi-plugin-slugify/issues/35) 
 | contentTypes[modelName]field | The name of the field to add the slug  | String | N/A | Yes |
 | contentTypes[modelName]references | The name(s) of the field(s) used to build the slug. If an array of fields is set it will result in a compound slug | String or Array | N/A | Yes |
 | slugifyWithCount | Duplicate strings will have their occurrence appended to the end of the slug | Boolean | false | No |
-| updateSlugs | If referenced fields have updates also update the slug. | Boolean | true | No |
 | skipUndefinedReferences | Skip reference fields that have no data. Mostly applicable to compound slug | Boolean | false | No |
 | slugifyOptions | The options to pass the the slugify function. All options can be found in the [slugify docs](https://github.com/sindresorhus/slugify#api) | Object | {} | No |
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Per [#35](https://github.com/ComfortablyCoding/strapi-plugin-slugify/issues/35) 
 | contentTypes[modelName]field | The name of the field to add the slug  | String | N/A | Yes |
 | contentTypes[modelName]references | The name(s) of the field(s) used to build the slug. If an array of fields is set it will result in a compound slug | String or Array | N/A | Yes |
 | slugifyWithCount | Duplicate strings will have their occurrence appended to the end of the slug | Boolean | false | No |
+| updateSlugs | If referenced fields have updates also update the slug. | Boolean | true | No |
 | skipUndefinedReferences | Skip reference fields that have no data. Mostly applicable to compound slug | Boolean | false | No |
 | slugifyOptions | The options to pass the the slugify function. All options can be found in the [slugify docs](https://github.com/sindresorhus/slugify#api) | Object | {} | No |
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Per [#35](https://github.com/ComfortablyCoding/strapi-plugin-slugify/issues/35) 
 | contentTypes[modelName]field | The name of the field to add the slug  | String | N/A | Yes |
 | contentTypes[modelName]references | The name(s) of the field(s) used to build the slug. If an array of fields is set it will result in a compound slug | String or Array | N/A | Yes |
 | slugifyWithCount | Duplicate strings will have their occurrence appended to the end of the slug | Boolean | false | No |
-| updateSlugs | If referenced fields have updates also update the slug. | Boolean | false | No |
+| shouldUpdateSlug | Allow the slug to be updated after initial generation. | Boolean | false | No |
 | skipUndefinedReferences | Skip reference fields that have no data. Mostly applicable to compound slug | Boolean | false | No |
 | slugifyOptions | The options to pass the the slugify function. All options can be found in the [slugify docs](https://github.com/sindresorhus/slugify#api) | Object | {} | No |
 

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -20,8 +20,8 @@ module.exports = ({ strapi }) => {
 	};
 
 	SUPPORTED_LIFECYCLES.forEach((lifecycle) => {
-		subscribe[lifecycle] = (ctx) => {
-			getPluginService(strapi, 'slugService').slugify(ctx);
+		subscribe[lifecycle] = async (ctx) => {
+			await getPluginService(strapi, 'slugService').slugify(ctx);
 		};
 	});
 

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -8,7 +8,7 @@ module.exports = {
 			contentTypes: {},
 			slugifyOptions: {},
 			slugifyWithCount: false,
-			updateSlugs: false,
+			shouldUpdateSlug: false,
 			skipUndefinedReferences: false,
 		};
 	},

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -8,6 +8,7 @@ module.exports = {
 			contentTypes: {},
 			slugifyOptions: {},
 			slugifyWithCount: false,
+			updateSlugs: false,
 			skipUndefinedReferences: false,
 		};
 	},

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -8,6 +8,7 @@ module.exports = {
 			contentTypes: {},
 			slugifyOptions: {},
 			slugifyWithCount: false,
+			updateSlugs: true,
 			skipUndefinedReferences: false,
 		};
 	},

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -8,7 +8,6 @@ module.exports = {
 			contentTypes: {},
 			slugifyOptions: {},
 			slugifyWithCount: false,
-			updateSlugs: true,
 			skipUndefinedReferences: false,
 		};
 	},

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -18,6 +18,7 @@ const pluginConfigSchema = yup.object().shape({
 		return yup.object().shape(shape);
 	}),
 	slugifyWithCount: yup.bool(),
+	updateSlugs: yup.bool(),
 	skipUndefinedReferences: yup.bool(),
 });
 

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -18,7 +18,7 @@ const pluginConfigSchema = yup.object().shape({
 		return yup.object().shape(shape);
 	}),
 	slugifyWithCount: yup.bool(),
-	updateSlugs: yup.bool(),
+	shouldUpdateSlug: yup.bool(),
 	skipUndefinedReferences: yup.bool(),
 });
 

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -12,7 +12,7 @@ module.exports = ({ strapi }) => ({
 		// Check to see if we have an existing reference and if it matches.
 		let current = null;
 		if (params.where && params.where.id) {
-			await strapi.entityService.findOne(entityModel.uid, params.where.id)
+			current = await strapi.entityService.findOne(entityModel.uid, params.where.id)
 		}
 		this.update(ctx, current)
 	},

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -10,15 +10,14 @@ module.exports = ({ strapi }) => ({
 		const { params, model: entityModel } = ctx;
 
 		// Check to see if we have an existing reference and if it matches.
-		if (ctx.params.where && ctx.params.where.id) {
-			let current = await strapi.entityService.findOne(entityModel.uid, ctx.params.where.id)
-			this.update(ctx, current)
-		} else {
-			this.update(ctx)
+		let current = null;
+		if (params.where && params.where.id) {
+			let current = await strapi.entityService.findOne(entityModel.uid, params.where.id)
 		}
+		this.update(ctx, current)
 	},
 
-	update(ctx, current = null) {
+	update(ctx, current) {
 
 		const settings = getPluginService(strapi, 'settingsService').get();
 		const { params, model: entityModel } = ctx;

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -62,7 +62,6 @@ module.exports = ({ strapi }) => ({
 			} else {
 				data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
 			}
-			console.log(data[field])
 		}
 
 	},

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -48,9 +48,9 @@ module.exports = ({ strapi }) => ({
 			}
 		}
 
-		// Make sure we are only updating if there isn't a slug, this is a new instance or the currently
-		// referenced fields don't match with the updated values.
-		if (shouldUpdate || !current || !data[field]) {
+		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
+		// If there isn't a current reference then proceed.
+		if ((shouldUpdate && settings.updateSlugs) || !current || !data[field]) {
 			const hasUndefinedFields = referenceFieldValues.length < references.length;
 			if ((!settings.skipUndefinedReferences && hasUndefinedFields) || !referenceFieldValues.length) {
 				return;
@@ -62,6 +62,7 @@ module.exports = ({ strapi }) => ({
 			} else {
 				data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
 			}
+			console.log(data[field])
 		}
 
 	},

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -12,7 +12,7 @@ module.exports = ({ strapi }) => ({
 		// Check to see if we have an existing reference and if it matches.
 		let current = null;
 		if (params.where && params.where.id) {
-			let current = await strapi.entityService.findOne(entityModel.uid, params.where.id)
+			await strapi.entityService.findOne(entityModel.uid, params.where.id)
 		}
 		this.update(ctx, current)
 	},

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -49,7 +49,7 @@ module.exports = ({ strapi }) => ({
 
 		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
 		// If there isn't a current reference then proceed.
-		if ((shouldUpdate && settings.updateSlugs) || !current || !data[field]) {
+		if ((shouldUpdate && settings.shoudUpdateSlug) || !current || !data[field]) {
 			const hasUndefinedFields = referenceFieldValues.length < references.length;
 			if ((!settings.skipUndefinedReferences && hasUndefinedFields) || !referenceFieldValues.length) {
 				return;

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -48,9 +48,9 @@ module.exports = ({ strapi }) => ({
 			}
 		}
 
-		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
-		// If there isn't a current reference then proceed.
-		if ((shouldUpdate && settings.updateSlugs) || !current || !data[field]) {
+		// Make sure we are only updating if there isn't a slug, this is a new instance or the currently
+		// referenced fields don't match with the updated values.
+		if (shouldUpdate || !current || !data[field]) {
 			const hasUndefinedFields = referenceFieldValues.length < references.length;
 			if ((!settings.skipUndefinedReferences && hasUndefinedFields) || !referenceFieldValues.length) {
 				return;

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -5,7 +5,21 @@ const { getPluginService } = require('../utils/getPluginService');
 const { toSlug, toSlugWithCount } = require('../utils/slugification');
 
 module.exports = ({ strapi }) => ({
-	slugify(ctx) {
+	async slugify(ctx) {
+
+		const { params, model: entityModel } = ctx;
+
+		// Check to see if we have an existing reference and if it matches.
+		if (ctx.params.where && ctx.params.where.id) {
+			let current = await strapi.entityService.findOne(entityModel.uid, ctx.params.where.id)
+			this.update(ctx, current)
+		} else {
+			this.update(ctx)
+		}
+	},
+
+	update(ctx, current = null) {
+
 		const settings = getPluginService(strapi, 'settingsService').get();
 		const { params, model: entityModel } = ctx;
 		const { data } = params;
@@ -23,32 +37,34 @@ module.exports = ({ strapi }) => ({
 			.map((r) => data[r]);
 
 
-		// If there is an existing reference then don't generate a new slug.
-		if (ctx.params.where && ctx.params.where.id) {
-			const current = await strapi.entityService.findOne(entityModel.uid, ctx.params.where.id);
-			if (current) {
-				let currentReferenceFieldValues = references
-					.filter((r) => typeof current[r] !== 'undefined' && current[r].length)
-					.map((r) => current[r]);
+		let shouldUpdate = true
+		if (current) {
+			let currentReferenceFieldValues = references
+				.filter((r) => typeof current[r] !== 'undefined' && current[r].length)
+				.map((r) => current[r]);
 
-				if (JSON.stringify(referenceFieldValues) == JSON.stringify(currentReferenceFieldValues)) {
-					return
-				}
+			if (JSON.stringify(referenceFieldValues) == JSON.stringify(currentReferenceFieldValues)) {
+				shouldUpdate = false
 			}
 		}
 
-		const hasUndefinedFields = referenceFieldValues.length < references.length;
-		if ((!settings.skipUndefinedReferences && hasUndefinedFields) || !referenceFieldValues.length) {
-			return;
+		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
+		// If there isn't a current reference then proceed.
+		if ((shouldUpdate && settings.updateSlugs) || !current || !data[field]) {
+			const hasUndefinedFields = referenceFieldValues.length < references.length;
+			if ((!settings.skipUndefinedReferences && hasUndefinedFields) || !referenceFieldValues.length) {
+				return;
+			}
+
+			referenceFieldValues = referenceFieldValues.join(' ');
+			if (settings.slugifyWithCount) {
+				data[field] = toSlugWithCount(referenceFieldValues, settings.slugifyOptions);
+			} else {
+				data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
+			}
+			console.log(data[field])
 		}
 
-		referenceFieldValues = referenceFieldValues.join(' ');
-		if (settings.slugifyWithCount) {
-			data[field] = toSlugWithCount(referenceFieldValues, settings.slugifyOptions);
-			return;
-		}
-
-		data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
 	},
 
 	async findOne(uid, query) {

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -49,7 +49,7 @@ module.exports = ({ strapi }) => ({
 
 		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
 		// If there isn't a current reference then proceed.
-		if ((shouldUpdate && settings.shoudUpdateSlug) || !current || !data[field]) {
+		if ((shouldUpdate && settings.shouldUpdateSlug) || !current || !data[field]) {
 			const hasUndefinedFields = referenceFieldValues.length < references.length;
 			if ((!settings.skipUndefinedReferences && hasUndefinedFields) || !referenceFieldValues.length) {
 				return;

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -37,8 +37,14 @@ module.exports = ({ strapi }) => ({
 
 
 		let shouldUpdate = true
-		if (current && current[field]) {
-			shouldUpdate = true;
+		if (current) {
+			let currentReferenceFieldValues = references
+				.filter((r) => typeof current[r] !== 'undefined' && current[r].length)
+				.map((r) => current[r]);
+
+			if (JSON.stringify(referenceFieldValues) == JSON.stringify(currentReferenceFieldValues)) {
+				shouldUpdate = false
+			}
 		}
 
 		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
@@ -52,9 +58,10 @@ module.exports = ({ strapi }) => ({
 			referenceFieldValues = referenceFieldValues.join(' ');
 			if (settings.slugifyWithCount) {
 				data[field] = toSlugWithCount(referenceFieldValues, settings.slugifyOptions);
-			} else {
-				data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
+				return
 			}
+
+			data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
 		}
 
 	},

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -38,7 +38,7 @@ module.exports = ({ strapi }) => ({
 
 		let shouldUpdate = true
 		if (current && current[field]) {
-		    shouldUpdate = true;
+			shouldUpdate = true;
 		}
 
 		// Reference the updateSlugs settings to determine if user wants slugs to be updated.
@@ -55,7 +55,6 @@ module.exports = ({ strapi }) => ({
 			} else {
 				data[field] = toSlug(referenceFieldValues, settings.slugifyOptions);
 			}
-			console.log(data[field])
 		}
 
 	},

--- a/server/services/slug-service.js
+++ b/server/services/slug-service.js
@@ -37,14 +37,8 @@ module.exports = ({ strapi }) => ({
 
 
 		let shouldUpdate = true
-		if (current) {
-			let currentReferenceFieldValues = references
-				.filter((r) => typeof current[r] !== 'undefined' && current[r].length)
-				.map((r) => current[r]);
-
-			if (JSON.stringify(referenceFieldValues) == JSON.stringify(currentReferenceFieldValues)) {
-				shouldUpdate = false
-			}
+		if (current && current[field]) {
+		    shouldUpdate = true;
 		}
 
 		// Reference the updateSlugs settings to determine if user wants slugs to be updated.


### PR DESCRIPTION
I believe this pull request should resolve this issue. 

Note this will prevent the slug from changing at all once it's been generated, which is how this should work in my opinion. Once a slug has been generated the only way it should be able to be updated is manually since it could result in 404 errors if a redirect is not put in place. 

I've tested it when updating the referenced fields and when creating a new entity and it seems to be working correctly.

This is the referenced issue.
https://github.com/ComfortablyCoding/strapi-plugin-slugify/issues/60
