### PR TITLE
fix(controller): use correct import for `transformResponse`

### DIFF
--- a/server/controllers/slug-controller.js
+++ b/server/controllers/slug-controller.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const { NotFoundError } = require('@strapi/utils').errors;
 const { getPluginService } = require('../utils/getPluginService');
-const { transformResponse } = require('@strapi/strapi/lib/core-api/controller/transform');
+const { transformResponse } = require('@strapi/strapi/dist/core-api/controller/transform');
 const { isValidFindSlugParams } = require('../utils/isValidFindSlugParams');
 const { sanitizeOutput } = require('../utils/sanitizeOutput');
 const { hasRequiredModelScopes } = require('../utils/hasRequiredModelScopes');


### PR DESCRIPTION
This PR updates the `transformResponse` import path to use the `dist` now that strapi is generated with ts

Resolves #108 