### PR TITLE
chore(release): 2.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/package",
 	"name": "strapi-plugin-slugify",
-	"version": "2.3.4",
+	"version": "2.3.5",
 	"description": "A plugin for Strapi Headless CMS that provides the ability to auto slugify a field for any content type.",
 	"scripts": {
 		"lint": "eslint . --fix",


### PR DESCRIPTION
This release adds the following changes
- fix `transformResponse` import path #109 
- update deps to latest #110 